### PR TITLE
feat: add PREPARING status to order workflow

### DIFF
--- a/src/main/java/com/example/ecommerce/entity/Order.java
+++ b/src/main/java/com/example/ecommerce/entity/Order.java
@@ -180,9 +180,13 @@ public class Order {
         this.deliveredAt = LocalDateTime.now();
     }
 
+    public void markAsPreparing() {
+        this.status = OrderStatus.PREPARING;
+    }
+
     // Enums
     public enum OrderStatus {
-        PENDING, CONFIRMED, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
+        PENDING, CONFIRMED, PREPARING, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
     }
 
     public enum PaymentStatus {


### PR DESCRIPTION
- Add PREPARING status between CONFIRMED and SHIPPED in OrderStatus enum
- Add markAsPreparing() helper method to Order entity
- Maintains backward compatibility with existing order statuses
- Enables more granular order tracking in the fulfillment process