### PR TITLE
feat: add PREPARING status to order workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # sample-spring-boot
+
+A sample Spring Boot e-commerce application demonstrating order management and workflow.
+
+## Order Workflow
+
+The application supports the following order statuses in sequence:
+
+1. **PENDING** - Initial status when order is created
+2. **CONFIRMED** - Order has been confirmed and payment processed
+3. **PREPARING** - Order is being prepared for shipment (items being picked, packed, etc.)
+4. **PROCESSING** - Order is being processed (legacy status, maintained for compatibility)
+5. **SHIPPED** - Order has been shipped with tracking information
+6. **DELIVERED** - Order has been delivered to customer
+7. **CANCELLED** - Order has been cancelled
+8. **RETURNED** - Order has been returned by customer
+
+### Order Status Transitions
+
+The typical order flow follows this sequence:
+```
+PENDING → CONFIRMED → PREPARING → SHIPPED → DELIVERED
+```
+
+Alternative flows:
+- Orders can be **CANCELLED** from any status before **SHIPPED**
+- Orders can be **RETURNED** after **DELIVERED**
+- **PROCESSING** status is maintained for backward compatibility
+
+### Helper Methods
+
+The `Order` entity provides convenient methods for status transitions:
+- `markAsPreparing()` - Transitions order to PREPARING status
+- `markAsShipped(trackingNumber)` - Transitions to SHIPPED with tracking info
+- `markAsDelivered()` - Transitions to DELIVERED status

--- a/src/main/java/com/example/ecommerce/entity/Order.java
+++ b/src/main/java/com/example/ecommerce/entity/Order.java
@@ -169,6 +169,10 @@ public class Order {
                 .sum();
     }
 
+    public void markAsPreparing() {
+        this.status = OrderStatus.PREPARING;
+    }
+
     public void markAsShipped(String trackingNumber) {
         this.status = OrderStatus.SHIPPED;
         this.shippedAt = LocalDateTime.now();
@@ -182,7 +186,7 @@ public class Order {
 
     // Enums
     public enum OrderStatus {
-        PENDING, CONFIRMED, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
+        PENDING, CONFIRMED, PREPARING, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
     }
 
     public enum PaymentStatus {


### PR DESCRIPTION
- Add new PREPARING status between CONFIRMED and SHIPPED in OrderStatus enum
- Add markAsPreparing() helper method for status transition
- Update README.md with comprehensive order workflow documentation
- Maintain backward compatibility with existing PROCESSING status

This enhancement provides better granularity in order tracking by distinguishing between order confirmation and the preparation phase before shipping.