### PR TITLE
feat: Add PREPARING status to order workflow

### DIFF
--- a/src/main/java/com/example/ecommerce/entity/Order.java
+++ b/src/main/java/com/example/ecommerce/entity/Order.java
@@ -175,6 +175,10 @@ public class Order {
         this.trackingNumber = trackingNumber;
     }
 
+    public void markAsPreparing() {
+        this.status = OrderStatus.PREPARING;
+    }
+
     public void markAsDelivered() {
         this.status = OrderStatus.DELIVERED;
         this.deliveredAt = LocalDateTime.now();
@@ -182,7 +186,7 @@ public class Order {
 
     // Enums
     public enum OrderStatus {
-        PENDING, CONFIRMED, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
+        PENDING, CONFIRMED, PREPARING, PROCESSING, SHIPPED, DELIVERED, CANCELLED, RETURNED
     }
 
     public enum PaymentStatus {


### PR DESCRIPTION
## Summary
This PR adds a new 'PREPARING' status between 'CONFIRMED' and 'SHIPPED' in the order workflow to better track the order preparation phase.

## Changes Made
- Added **PREPARING** status to the OrderStatus enum (positioned between CONFIRMED and SHIPPED)
- Added **markAsPreparing()** helper method to transition orders to the PREPARING state
- Updated OrderStatus enum order: PENDING → CONFIRMED → **PREPARING** → PROCESSING → SHIPPED → DELIVERED → CANCELLED → RETURNED

## Technical Details
- Modified: `src/main/java/com/example/ecommerce/entity/Order.java`
- The new status is stored as a string in the database (using @Enumerated(EnumType.STRING))
- No database migration required as enum values are stored as strings
- The OrderRepository methods will automatically support the new status

## Testing
No tests were run as per requirements. Manual testing recommended to verify:
- Orders can be transitioned to PREPARING status
- Database correctly stores the new status value
- Existing order queries work with the new status